### PR TITLE
use script parameters instead of read-host

### DIFF
--- a/BwR.ps1
+++ b/BwR.ps1
@@ -1,64 +1,50 @@
-## Version 0.9.9
+﻿## Version 0.9.9
 ## Created by: Ankith Mankunnu
 ## Backup Files to external drive using Robocopy or other options.
 ## Usage: Call the script from PS console or IDE.
 ##        .\BwR.ps1
+##        .\BwR.ps1 -Source <path> -Destination <path>
 
-Write-Host = "Select your operation"
-Write-Host = "1. Robocopy"
-Write-Host = "2. AzCopy"
-Write-Host = "0. Clear/Exit"
-$choice = Read-Host "Please enter your choice. `n" 
-if ($choice -match '^[0-9]+$')
+[CmdletBinding()]
+Param (
+    [Parameter( Mandatory = $true )]
+    [ValidateNotNullOrEmpty()]
+    [string]$Source,
+    [Parameter( Mandatory = $true )]
+    [ValidateNotNullOrEmpty()]
+    [string]$Destination,
+    [ValidateSet('Robocopy', 'AzCopy')]
+    [string]$Operation = 'Robocopy'
+)
+
+switch ($Operation)
 {
-    switch ($choice) 
+    'Robocopy'
     {
-        1
+        $date = Get-Date -f ddMMyyHHmmss
+        if (($source | Test-path -PathType Any) -or ($destination | Test-path -PathType Any))
         {
-            $date = Get-Date -f ddMMyyHHmmss
-            $source = Read-Host 'Source location'
-            $destination = Read-Host 'Destination location'
-            if ([string]::IsNullOrEmpty($source) -or [string]::IsNullOrEmpty($destination) -or [string]::IsNullOrWhiteSpace($source) -or [string]::IsNullOrWhiteSpace($destination))
-            {
-                Clear-Host
-                Write-Host "Source or Destination is empty" -ForegroundColor Red
-                Start-Sleep -Seconds 5
-            }
-            elseif (($source | Test-path -PathType Any) -or ($destination | Test-path -PathType Any))
-            {
-                [string]$log = $destination + "\RobocopyLog" + $date + ".log"
-                New-Item $log -ItemType File -Force | Out-Null
-                robocopy $source $destination /E /XO /MT /LOG:$log /TEE
-                Write-Host "Copy completed, Check $log for any issue." -ForegroundColor Green
-            }
-            else
-            {
-                Clear-Host
-                Write-Host "Path entered could be wrong" -ForegroundColor Red
-                Start-Sleep -Seconds 5
-            }
+            [string]$log = $destination + "\RobocopyLog" + $date + ".log"
+            New-Item $log -ItemType File -Force | Out-Null
+            robocopy $source $destination /E /XO /MT /LOG:$log /TEE
+            Write-Host "Copy completed, Check $log for any issue." -ForegroundColor Green
         }
-        2
+        else
         {
             Clear-Host
-            Write-Host "Coming soon!!" -ForegroundColor Yellow
-        }
-        0
-        {
-            Clear-Host
-            Write-Host "Clearing screen" -ForegroundColor Yellow
-            Start-Sleep -Seconds 2
-        }
-        Default 
-        {
-            Clear-Host
-            Write-Host "Wrong Operation" -ForegroundColor Red
+            Write-Host "Path entered could be wrong" -ForegroundColor Red
             Start-Sleep -Seconds 5
         }
     }
-}
-else
-{
-    Clear-Host
-    Write-Host "Invalid Choice!!" -ForegroundColor DarkRed
+    'AzCopy'
+    {
+        Clear-Host
+        Write-Host "Coming soon!!" -ForegroundColor Yellow
+    }
+    Default 
+    {
+        Clear-Host
+        Write-Host "Wrong Operation" -ForegroundColor Red
+        Start-Sleep -Seconds 5
+    }
 }


### PR DESCRIPTION
Hi,

I modified the script to use powershell script parameters for `$Source`, `$Destination` and `$Operation` ($choice).

This allows you to now run the script like this:

```powershell
.\BwR.ps1 -Source C:\Test-Destination E:\Test -Operation Robocopy
```

immediately passing these values on the command-line and without PowerShell asking for the source, destination etc. values.

If the parameters are omitted (e.g. just running `.\BwR.ps1`) then PowerShell will automatically ask for values for any mandatory parameters, thus replacing the manual Read-Host code. Setting the `[ValidateNotNullOrEmpty()]` attribute on a parameter also automatically ensures it cannot be null or empty, again removing the need for manually checking this in the script code.